### PR TITLE
feat: add --pattern option for wildcard package matching in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,23 +33,23 @@ npx npm-check-last-publish zod react
 | --------------- | ---------------------------------------- | ------- | ------------------------- |
 | `--sort <TYPE>` | Sort packages by a specific field        | `date`  | `name`, `date`, `average` |
 | `--order <DIR>` | Sort direction (ascending or descending) | `asc`   | `asc`, `desc`             |
+| `--pattern` | 	Enable wildcard pattern matching for package names (only applies to dependencies listed in your project)  | (off)   |              |
 
 ## Examples
-### Check all local dependencies
-```bash
-npx npm-check-last-publish
-```
-### Check specific packages
-```bash
-npx npm-check-last-publish zod react
-```
-### Sort alphabetically
+#### Sort alphabetically
 ```bash
 npx npm-check-last-publish --sort name
 ```
-### Sort by average publish frequency, descending
+#### Sort by average publish frequency, descending
 ```bash
 npx npm-check-last-publish --sort average --order desc zod react cspell
+```
+#### Check packages matching a wildcard pattern
+```bash
+npx npm-check-last-publish --pattern "@types/*"
+```
+```bash
+npx npm-check-last-publish --pattern "react-*"
 ```
 
 ## Help

--- a/cspell.json
+++ b/cspell.json
@@ -3,5 +3,5 @@
   "version": "0.2",
   "ignorePaths": ["node_modules", "package.json", "*.svg"],
   "language": "en",
-  "words": ["Fullstacks", "codepaths"]
+  "words": ["Fullstacks", "codepaths", "nocase"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "cli-table3": "0.6.5",
         "commander": "14.0.0",
         "date-fns": "4.1.0",
+        "minimatch": "10.0.3",
         "ora": "8.2.0"
       },
       "bin": {
@@ -1516,6 +1517,27 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -4610,6 +4632,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minimist": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "cli-table3": "0.6.5",
     "commander": "14.0.0",
     "date-fns": "4.1.0",
+    "minimatch": "10.0.3",
     "ora": "8.2.0"
   },
   "devDependencies": {

--- a/src/lib/cli-options.ts
+++ b/src/lib/cli-options.ts
@@ -36,6 +36,7 @@ export function getCliOptions() {
       `Sort order: ${VALID_SORT_ORDER.join(", ")}`,
       "asc",
     )
+    .option("--pattern", "Enable wildcard pattern matching for package names")
     .helpOption("-h, --help", "Show help")
     .addHelpText(
       "after",
@@ -44,15 +45,22 @@ Examples:
   $ npm-check-last-publish --sort name --order asc
   $ npm-check-last-publish --sort average
   $ npm-check-last-publish        # defaults to --sort date --order asc
+  $ npm-check-last-publish --pattern "@types/*"
+  $ npm-check-last-publish --pattern "react-*"
 `,
     )
     .parse(process.argv);
 
-  const { sort, order } = program.opts<{ sort: SortBy; order: SortOrder }>();
+  const { sort, order, pattern } = program.opts<{
+    sort: SortBy;
+    order: SortOrder;
+    pattern: boolean;
+  }>();
   const packages = program.args;
 
   return {
     packages,
+    pattern,
     sortBy: validateOption(sort, VALID_SORT_BY, "sort"),
     sortOrder: validateOption(order, VALID_SORT_ORDER, "order"),
   };

--- a/src/lib/expand-package-patterns.ts
+++ b/src/lib/expand-package-patterns.ts
@@ -1,0 +1,16 @@
+import { minimatch } from "minimatch";
+
+export function expandPackagePatterns(
+  patterns: string[],
+  allNames: string[],
+): string[] {
+  const matched = patterns.flatMap((pattern) => {
+    if (pattern.includes("*")) {
+      return allNames.filter((pkg) =>
+        minimatch(pkg, pattern, { nocase: true }),
+      );
+    }
+    return [pattern.toLowerCase()];
+  });
+  return [...new Set(matched)];
+}

--- a/src/lib/fetch-packages.ts
+++ b/src/lib/fetch-packages.ts
@@ -1,11 +1,33 @@
+import type { PackagePublishInfo } from "../types.js";
+import { expandPackagePatterns } from "./expand-package-patterns.js";
 import { getAllDependencies } from "./get-all-dependencies.js";
 import { getPackagePublishDate } from "./get-package-publish-date.js";
 
-export async function fetchPackageInfoList(inputPackages: string[] = []) {
-  const packagesToCheck =
-    inputPackages.length === 0
-      ? Object.keys(await getAllDependencies())
-      : inputPackages.map((p) => p.toLowerCase());
+type PackageInfoResult = {
+  results: (PackagePublishInfo | null)[];
+  errors: { package: string; error: Error }[];
+};
+
+export async function fetchPackageInfoList(
+  inputPackages: string[],
+  pattern: boolean,
+): Promise<PackageInfoResult> {
+  const allDeps = await getAllDependencies();
+  const allPackageNames = Object.keys(allDeps);
+
+  let packagesToCheck: string[];
+
+  if (inputPackages.length === 0) {
+    packagesToCheck = allPackageNames;
+  } else if (pattern) {
+    packagesToCheck = expandPackagePatterns(inputPackages, allPackageNames);
+  } else {
+    packagesToCheck = inputPackages.map((p) => p.toLowerCase());
+  }
+
+  if (packagesToCheck.length === 0) {
+    throw new Error("No matching packages found for given patterns.");
+  }
 
   const errors: { package: string; error: Error }[] = [];
 
@@ -16,11 +38,7 @@ export async function fetchPackageInfoList(inputPackages: string[] = []) {
       } catch (err) {
         const message =
           err instanceof Error ? err.message.split("\n")[0] : String(err);
-
-        errors.push({
-          package: pkgName,
-          error: new Error(message),
-        });
+        errors.push({ package: pkgName, error: new Error(message) });
         return null;
       }
     }),

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,11 +9,11 @@ import { renderTable } from "./lib/render-table.js";
 
 async function main() {
   try {
-    const { packages, sortBy, sortOrder } = getCliOptions();
+    const { packages, sortBy, sortOrder, pattern } = getCliOptions();
 
     loading.start();
 
-    const { results, errors } = await fetchPackageInfoList(packages);
+    const { results, errors } = await fetchPackageInfoList(packages, pattern);
     loading.stop();
 
     const sortedInfo = processPackageData(


### PR DESCRIPTION
Added `--pattern `option to **CLI** to support wildcard matching of package names.  

This helps users filter dependencies using patterns like "@types/*" or "react-*".  