### PR TITLE
feat: add customizable warning/error thresholds and colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ A simple CLI tool that helps developers check the last published versions of the
 - Displays outdated dependencies in a clear table format.
 - Shows the last published time, average and version of each dependency.
 - Helps developers keep their dependencies up to date.
+- Supports wildcard pattern matching for package names.
+- Customizable warning/error day thresholds and colors (supports named colors or HEX).
 
 ![report screenshot](https://github.com/fullstacksjs/npm-check-last-publish/blob/main/assets/demo.png?raw=true)
 
@@ -29,11 +31,16 @@ npx npm-check-last-publish zod react
 ```
 
 ## CLI Options
-| Option          | Description                              | Default | Allowed Values            |
-| --------------- | ---------------------------------------- | ------- | ------------------------- |
-| `--sort <TYPE>` | Sort packages by a specific field        | `date`  | `name`, `date`, `average` |
-| `--order <DIR>` | Sort direction (ascending or descending) | `asc`   | `asc`, `desc`             |
-| `--pattern` | 	Enable wildcard pattern matching for package names (only applies to dependencies listed in your project)  | (off)   |              |
+| Option                  | Description                                        | Default  | Allowed Values                                                              |
+| ----------------------- | -------------------------------------------------- | -------- | --------------------------------------------------------------------------- |
+| `--sort <TYPE>`         | Sort packages by a specific field                  | `date`   | `name`, `date`, `average`                                                   |
+| `--order <DIR>`         | Sort direction (ascending or descending)           | `asc`    | `asc`, `desc`                                                               |
+| `--pattern`             | Enable wildcard pattern matching for package names | (off)    | Glob pattern, e.g., `"react-*"` or `"@types/*"`                                                                         |
+| `--warn-days <NUMBER>`  | Days threshold for warning                         | `180`     | Any positive integer                                                        |
+| `--error-days <NUMBER>` | Days threshold for error                           | `365`    | Any positive integer                                                        |
+| `--safe-color <COLOR>`  | Color for safe zone (named or HEX)                 | `green`  | Any [chalk named color](https://github.com/chalk/chalk#colors) or `#RRGGBB` |
+| `--warn-color <COLOR>`  | Color for warning zone (named or HEX)              | `yellow` | Any [chalk named color](https://github.com/chalk/chalk#colors) or `#RRGGBB`                                                                |
+| `--error-color <COLOR>` | Color for error zone (named or HEX)                | `red`    | Any [chalk named color](https://github.com/chalk/chalk#colors) or `#RRGGBB`                                                                |
 
 ## Examples
 #### Sort alphabetically
@@ -50,6 +57,18 @@ npx npm-check-last-publish --pattern "@types/*"
 ```
 ```bash
 npx npm-check-last-publish --pattern "react-*"
+```
+#### Customize warning and error thresholds
+```bash
+npx npm-check-last-publish --warn-days 60 --error-days 120
+```
+#### Use custom colors (named)
+```bash
+npx npm-check-last-publish --safe-color green --warn-color yellow --error-color red
+```
+#### Use custom colors (HEX)
+```bash
+npx npm-check-last-publish --safe-color "#00ff00" --warn-color "#ffff00" --error-color "#ff0000"
 ```
 
 ## Help

--- a/cspell.json
+++ b/cspell.json
@@ -3,5 +3,5 @@
   "version": "0.2",
   "ignorePaths": ["node_modules", "package.json", "*.svg"],
   "language": "en",
-  "words": ["Fullstacks", "codepaths", "nocase"]
+  "words": ["Fullstacks", "codepaths", "nocase", "RRGGBB"]
 }

--- a/src/lib/cli-options.ts
+++ b/src/lib/cli-options.ts
@@ -1,24 +1,21 @@
+import { foregroundColorNames } from "chalk";
 import { Command } from "commander";
 import pkg from "../../package.json" with { type: "json" };
-import type { SortBy, SortOrder } from "../types.js";
-
-const VALID_SORT_BY: SortBy[] = ["name", "date", "average"];
-const VALID_SORT_ORDER: SortOrder[] = ["asc", "desc"];
-
-function validateOption<T extends string>(
-  value: string,
-  validValues: readonly T[],
-  optionName: string,
-): T {
-  const lowerValue = value.toLowerCase() as T;
-  if (!validValues.includes(lowerValue)) {
-    console.error(
-      `Invalid --${optionName}: '${value}'. Must be one of: ${validValues.join(", ")}`,
-    );
-    process.exit(1);
-  }
-  return lowerValue;
-}
+import type {
+  ColorOption,
+  Colors,
+  SortBy,
+  SortOrder,
+  Thresholds,
+} from "../types.js";
+import {
+  DEFAULT_COLORS,
+  DEFAULT_ORDER,
+  DEFAULT_SORT,
+  DEFAULT_THRESHOLDS,
+  VALID_SORT_BY,
+  VALID_SORT_ORDER,
+} from "./constants.js";
 
 export function getCliOptions() {
   const program = new Command()
@@ -26,17 +23,43 @@ export function getCliOptions() {
     .description(pkg.description)
     .version(pkg.version)
     .usage("[packages...] [options]")
-    .argument(
-      "[packages...]",
-      "Optional. Names of packages to check. If omitted, all local dependencies will be used.",
+    .argument("[packages...]", "Optional. Names of packages to check.")
+    .option(
+      "--sort <TYPE>",
+      `Sort by: ${VALID_SORT_BY.join(", ")}`,
+      DEFAULT_SORT,
     )
-    .option("--sort <TYPE>", `Sort by: ${VALID_SORT_BY.join(", ")}`, "date")
     .option(
       "--order <DIRECTION>",
       `Sort order: ${VALID_SORT_ORDER.join(", ")}`,
-      "asc",
+      DEFAULT_ORDER,
     )
     .option("--pattern", "Enable wildcard pattern matching for package names")
+    .option(
+      "--warn-days <NUMBER>",
+      "Days threshold for warning",
+      String(DEFAULT_THRESHOLDS.warn),
+    )
+    .option(
+      "--error-days <NUMBER>",
+      "Days threshold for error",
+      String(DEFAULT_THRESHOLDS.error),
+    )
+    .option(
+      "--safe-color <COLOR>",
+      `Color for safe zone (hex like "#00ff00" or one of: ${foregroundColorNames.join(", ")})`,
+      DEFAULT_COLORS.safe,
+    )
+    .option(
+      "--warn-color <COLOR>",
+      `Color for warning zone (hex like "#ffcc00" or one of: ${foregroundColorNames.join(", ")})`,
+      DEFAULT_COLORS.warn,
+    )
+    .option(
+      "--error-color <COLOR>",
+      `Color for error zone (hex like "#ff0000" or one of: ${foregroundColorNames.join(", ")})`,
+      DEFAULT_COLORS.error,
+    )
     .helpOption("-h, --help", "Show help")
     .addHelpText(
       "after",
@@ -47,21 +70,52 @@ Examples:
   $ npm-check-last-publish        # defaults to --sort date --order asc
   $ npm-check-last-publish --pattern "@types/*"
   $ npm-check-last-publish --pattern "react-*"
+  $ npm-check-last-publish --warn-days 60 --error-days 120
+  $ npm-check-last-publish --safe-color green --warn-color yellow --error-color red
+  $ npm-check-last-publish --safe-color "#00ff00" --warn-color "#ffff00" --error-color "#ff0000"
 `,
     )
     .parse(process.argv);
 
-  const { sort, order, pattern } = program.opts<{
+  const {
+    sort,
+    order,
+    pattern,
+    warnDays,
+    errorDays,
+    safeColor,
+    warnColor,
+    errorColor,
+  } = program.opts<{
     sort: SortBy;
     order: SortOrder;
     pattern: boolean;
+    warnDays: number;
+    errorDays: number;
+    safeColor: ColorOption;
+    warnColor: ColorOption;
+    errorColor: ColorOption;
   }>();
+
   const packages = program.args;
+
+  const thresholds: Thresholds = {
+    warn: warnDays,
+    error: errorDays,
+  };
+
+  const colors: Colors = {
+    safe: safeColor,
+    warn: warnColor,
+    error: errorColor,
+  };
 
   return {
     packages,
     pattern,
-    sortBy: validateOption(sort, VALID_SORT_BY, "sort"),
-    sortOrder: validateOption(order, VALID_SORT_ORDER, "order"),
+    sortBy: sort,
+    sortOrder: order,
+    thresholds,
+    colors,
   };
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,17 @@
+import type { Colors, SortBy, SortOrder, Thresholds } from "../types.js";
+
+export const DEFAULT_THRESHOLDS: Thresholds = {
+  warn: 180,
+  error: 365,
+};
+
+export const DEFAULT_COLORS: Colors = {
+  safe: "green",
+  warn: "yellow",
+  error: "red",
+};
+
+export const VALID_SORT_BY: SortBy[] = ["name", "date", "average"];
+export const VALID_SORT_ORDER: SortOrder[] = ["asc", "desc"];
+export const DEFAULT_SORT: SortBy = "date";
+export const DEFAULT_ORDER: SortOrder = "asc";

--- a/src/lib/format-package-info.ts
+++ b/src/lib/format-package-info.ts
@@ -1,9 +1,24 @@
 import { differenceInDays } from "date-fns";
-import type { PackageInfo, PackagePublishInfo } from "../types.js";
+import type {
+  Colors,
+  PackageInfo,
+  PackagePublishInfo,
+  Thresholds,
+} from "../types.js";
 import { getAveragePublishDays } from "./get-average-publish-days.js";
 import { getColorArea } from "./get-color-area.js";
 
-export function formatPackageInfo(pkg: PackagePublishInfo): PackageInfo {
+interface FormatPackageOptions {
+  pkg: PackagePublishInfo;
+  thresholds: Thresholds;
+  colors: Colors;
+}
+
+export function formatPackageInfo({
+  pkg,
+  thresholds,
+  colors,
+}: FormatPackageOptions): PackageInfo {
   const { packageName, packagePublishDate, packageVersion, publishedTimes } =
     pkg;
 
@@ -15,7 +30,7 @@ export function formatPackageInfo(pkg: PackagePublishInfo): PackageInfo {
     version: packageVersion,
     date: packagePublishDate,
     diffDays,
-    area: getColorArea(diffDays),
+    area: getColorArea({ diffDays, thresholds, colors }),
     averagePublishDays,
   };
 }

--- a/src/lib/get-color-area.ts
+++ b/src/lib/get-color-area.ts
@@ -1,24 +1,16 @@
-const THRESHOLDS = {
-  green: 0,
-  yellow: 180,
-  red: 365,
-} as const;
+import type { Area, Colors, Thresholds } from "../types.js";
+export interface GetColorAreaOptions {
+  diffDays: number;
+  thresholds: Thresholds;
+  colors: Colors;
+}
 
-const COLORS = {
-  green: "green",
-  yellow: "yellow",
-  red: "red",
-} as const;
-
-export type Area = (typeof COLORS)[keyof typeof COLORS];
-
-export const GREEN_AREA = (target: number) => target >= THRESHOLDS.green;
-export const YELLOW_AREA = (target: number) => target >= THRESHOLDS.yellow;
-export const RED_AREA = (target: number) => target >= THRESHOLDS.red;
-
-export function getColorArea(diffDays: number): Area {
-  if (RED_AREA(diffDays)) return COLORS.red;
-  if (YELLOW_AREA(diffDays)) return COLORS.yellow;
-  if (GREEN_AREA(diffDays)) return COLORS.green;
-  return COLORS.green;
+export function getColorArea({
+  diffDays,
+  thresholds,
+  colors,
+}: GetColorAreaOptions): Area {
+  if (diffDays >= thresholds.error) return colors.error;
+  if (diffDays >= thresholds.warn) return colors.warn;
+  return colors.safe;
 }

--- a/src/lib/process-packages.ts
+++ b/src/lib/process-packages.ts
@@ -1,18 +1,35 @@
+import type {
+  Colors,
+  PackagePublishInfo,
+  SortBy,
+  SortOrder,
+  Thresholds,
+} from "../types.js";
 import { formatPackageInfo } from "./format-package-info.js";
 import { sortPackages } from "./sort-packages.js";
+
+interface ProcessPackageOptions {
+  results: PackagePublishInfo[];
+  sortBy: SortBy;
+  sortOrder: SortOrder;
+  thresholds: Thresholds;
+  colors: Colors;
+}
 
 function isDefined<T>(value: T | undefined | null): value is T {
   return value !== undefined && value !== null;
 }
 
-import type { PackagePublishInfo, SortBy, SortOrder } from "../types.js";
-
-export function processPackageData(
-  results: PackagePublishInfo[],
-  sortBy: SortBy,
-  sortOrder: SortOrder,
-) {
+export function processPackageData({
+  results,
+  sortBy,
+  sortOrder,
+  thresholds,
+  colors,
+}: ProcessPackageOptions) {
   const validResults = results.filter(isDefined);
-  const formatted = validResults.map(formatPackageInfo);
+  const formatted = validResults.map((pkg) =>
+    formatPackageInfo({ pkg, thresholds, colors }),
+  );
   return sortPackages(formatted, sortBy, sortOrder);
 }

--- a/src/lib/render-table.ts
+++ b/src/lib/render-table.ts
@@ -1,7 +1,21 @@
-import chalk from "chalk";
+import chalk, { type ForegroundColorName, foregroundColorNames } from "chalk";
 import Table from "cli-table3";
 import { formatDistance } from "date-fns";
 import type { PackageInfo } from "../types.js";
+
+export function getChalkColor(color: string): (text: string) => string {
+  if (color.startsWith("#")) {
+    return chalk.hex(color);
+  }
+
+  if (foregroundColorNames.includes(color as ForegroundColorName)) {
+    return chalk[color as ForegroundColorName];
+  }
+
+  throw new Error(
+    `Invalid color: '${color}'. Must be a valid chalk color name or hex code.`,
+  );
+}
 
 const TABLE_HEADER_TITLES = ["Name", "Version", "Date", "Average"] as const;
 
@@ -12,15 +26,15 @@ export function renderTable(packagesInfo: PackageInfo[]) {
 
   for (const pkg of packagesInfo) {
     const { area, averagePublishDays, date, name, version } = pkg;
-    const color = chalk[area];
+    const colorFn = getChalkColor(area);
     const formattedDate = formatDistance(date, new Date(), {
       addSuffix: true,
     });
 
     table.push([
-      color(name),
-      color(version),
-      color(formattedDate),
+      colorFn(name),
+      colorFn(version),
+      colorFn(formattedDate),
       chalk.hex("#2dd4bf")(
         averagePublishDays === 1 ? "daily" : `every ${averagePublishDays} days`,
       ),

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,15 +9,18 @@ import { renderTable } from "./lib/render-table.js";
 
 async function main() {
   try {
-    const { packages, sortBy, sortOrder, pattern } = getCliOptions();
+    const { packages, sortBy, sortOrder, pattern, colors, thresholds } =
+      getCliOptions();
 
     const { results, errors } = await fetchPackageInfoList(packages, pattern);
 
-    const sortedInfo = processPackageData(
-      results.filter((r) => r !== null),
+    const sortedInfo = processPackageData({
+      results: results.filter((r) => r !== null),
       sortBy,
       sortOrder,
-    );
+      thresholds,
+      colors,
+    });
 
     renderTable(sortedInfo);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,6 @@
-import type { Area } from "./lib/get-color-area.js";
+import type { ForegroundColorName } from "chalk";
+
+export type Area = string;
 
 export type PackageInfo = {
   name: string;
@@ -18,3 +20,13 @@ export type PackagePublishInfo = {
 
 export type SortBy = "name" | "date" | "average";
 export type SortOrder = "asc" | "desc";
+export type ColorOption = ForegroundColorName | `#${string}`;
+export interface Thresholds {
+  warn: number;
+  error: number;
+}
+export interface Colors {
+  safe: ColorOption;
+  warn: ColorOption;
+  error: ColorOption;
+}


### PR DESCRIPTION
Add **CLI** support for safe, warning, and error zones, allowing users to customize thresholds (days) and colors (named or HEX) for each zone.