### PR TITLE
refactor: remove color options in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A simple CLI tool that helps developers check the last published versions of the
 - Shows the last published time, average and version of each dependency.
 - Helps developers keep their dependencies up to date.
 - Supports wildcard pattern matching for package names.
-- Customizable warning/error day thresholds and colors (supports named colors or HEX).
+- Customizable warning/error day thresholds.
 
 ![report screenshot](https://github.com/fullstacksjs/npm-check-last-publish/blob/main/assets/demo.png?raw=true)
 
@@ -38,9 +38,6 @@ npx npm-check-last-publish zod react
 | `--pattern`             | Enable wildcard pattern matching for package names | (off)    | Glob pattern, e.g., `"react-*"` or `"@types/*"`                                                                         |
 | `--warn-days <NUMBER>`  | Days threshold for warning                         | `180`     | Any positive integer                                                        |
 | `--error-days <NUMBER>` | Days threshold for error                           | `365`    | Any positive integer                                                        |
-| `--safe-color <COLOR>`  | Color for safe zone (named or HEX)                 | `green`  | Any [chalk named color](https://github.com/chalk/chalk#colors) or `#RRGGBB` |
-| `--warn-color <COLOR>`  | Color for warning zone (named or HEX)              | `yellow` | Any [chalk named color](https://github.com/chalk/chalk#colors) or `#RRGGBB`                                                                |
-| `--error-color <COLOR>` | Color for error zone (named or HEX)                | `red`    | Any [chalk named color](https://github.com/chalk/chalk#colors) or `#RRGGBB`                                                                |
 
 ## Examples
 #### Sort alphabetically
@@ -61,14 +58,6 @@ npx npm-check-last-publish --pattern "react-*"
 #### Customize warning and error thresholds
 ```bash
 npx npm-check-last-publish --warn-days 60 --error-days 120
-```
-#### Use custom colors (named)
-```bash
-npx npm-check-last-publish --safe-color green --warn-color yellow --error-color red
-```
-#### Use custom colors (HEX)
-```bash
-npx npm-check-last-publish --safe-color "#00ff00" --warn-color "#ffff00" --error-color "#ff0000"
 ```
 
 ## Help

--- a/cspell.json
+++ b/cspell.json
@@ -3,5 +3,5 @@
   "version": "0.2",
   "ignorePaths": ["node_modules", "package.json", "*.svg"],
   "language": "en",
-  "words": ["Fullstacks", "codepaths", "nocase", "RRGGBB"]
+  "words": ["Fullstacks", "codepaths", "nocase"]
 }

--- a/src/lib/cli-options.ts
+++ b/src/lib/cli-options.ts
@@ -1,15 +1,7 @@
-import { foregroundColorNames } from "chalk";
 import { Command } from "commander";
 import pkg from "../../package.json" with { type: "json" };
-import type {
-  ColorOption,
-  Colors,
-  SortBy,
-  SortOrder,
-  Thresholds,
-} from "../types.js";
+import type { SortBy, SortOrder, Thresholds } from "../types.js";
 import {
-  DEFAULT_COLORS,
   DEFAULT_ORDER,
   DEFAULT_SORT,
   DEFAULT_THRESHOLDS,
@@ -45,21 +37,6 @@ export function getCliOptions() {
       "Days threshold for error",
       String(DEFAULT_THRESHOLDS.error),
     )
-    .option(
-      "--safe-color <COLOR>",
-      `Color for safe zone (hex like "#00ff00" or one of: ${foregroundColorNames.join(", ")})`,
-      DEFAULT_COLORS.safe,
-    )
-    .option(
-      "--warn-color <COLOR>",
-      `Color for warning zone (hex like "#ffcc00" or one of: ${foregroundColorNames.join(", ")})`,
-      DEFAULT_COLORS.warn,
-    )
-    .option(
-      "--error-color <COLOR>",
-      `Color for error zone (hex like "#ff0000" or one of: ${foregroundColorNames.join(", ")})`,
-      DEFAULT_COLORS.error,
-    )
     .helpOption("-h, --help", "Show help")
     .addHelpText(
       "after",
@@ -67,34 +44,19 @@ export function getCliOptions() {
 Examples:
   $ npm-check-last-publish --sort name --order asc
   $ npm-check-last-publish --sort average
-  $ npm-check-last-publish        # defaults to --sort date --order asc
   $ npm-check-last-publish --pattern "@types/*"
   $ npm-check-last-publish --pattern "react-*"
   $ npm-check-last-publish --warn-days 60 --error-days 120
-  $ npm-check-last-publish --safe-color green --warn-color yellow --error-color red
-  $ npm-check-last-publish --safe-color "#00ff00" --warn-color "#ffff00" --error-color "#ff0000"
 `,
     )
     .parse(process.argv);
 
-  const {
-    sort,
-    order,
-    pattern,
-    warnDays,
-    errorDays,
-    safeColor,
-    warnColor,
-    errorColor,
-  } = program.opts<{
+  const { sort, order, pattern, warnDays, errorDays } = program.opts<{
     sort: SortBy;
     order: SortOrder;
     pattern: boolean;
     warnDays: number;
     errorDays: number;
-    safeColor: ColorOption;
-    warnColor: ColorOption;
-    errorColor: ColorOption;
   }>();
 
   const packages = program.args;
@@ -104,18 +66,11 @@ Examples:
     error: errorDays,
   };
 
-  const colors: Colors = {
-    safe: safeColor,
-    warn: warnColor,
-    error: errorColor,
-  };
-
   return {
     packages,
     pattern,
     sortBy: sort,
     sortOrder: order,
     thresholds,
-    colors,
   };
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,15 +1,21 @@
-import type { Colors, SortBy, SortOrder, Thresholds } from "../types.js";
+import type {
+  Area,
+  SortBy,
+  SortOrder,
+  TerminalColor,
+  Thresholds,
+} from "../types.js";
 
 export const DEFAULT_THRESHOLDS: Thresholds = {
   warn: 180,
   error: 365,
 };
 
-export const DEFAULT_COLORS: Colors = {
+export const AREA_COLORS: Record<Area, TerminalColor> = {
   safe: "green",
   warn: "yellow",
   error: "red",
-};
+} as const;
 
 export const VALID_SORT_BY: SortBy[] = ["name", "date", "average"];
 export const VALID_SORT_ORDER: SortOrder[] = ["asc", "desc"];

--- a/src/lib/format-package-info.ts
+++ b/src/lib/format-package-info.ts
@@ -1,23 +1,16 @@
 import { differenceInDays } from "date-fns";
-import type {
-  Colors,
-  PackageInfo,
-  PackagePublishInfo,
-  Thresholds,
-} from "../types.js";
+import type { PackageInfo, PackagePublishInfo, Thresholds } from "../types.js";
 import { getAveragePublishDays } from "./get-average-publish-days.js";
 import { getColorArea } from "./get-color-area.js";
 
 interface FormatPackageOptions {
   pkg: PackagePublishInfo;
   thresholds: Thresholds;
-  colors: Colors;
 }
 
 export function formatPackageInfo({
   pkg,
   thresholds,
-  colors,
 }: FormatPackageOptions): PackageInfo {
   const { packageName, packagePublishDate, packageVersion, publishedTimes } =
     pkg;
@@ -30,7 +23,7 @@ export function formatPackageInfo({
     version: packageVersion,
     date: packagePublishDate,
     diffDays,
-    area: getColorArea({ diffDays, thresholds, colors }),
+    area: getColorArea({ diffDays, thresholds }),
     averagePublishDays,
   };
 }

--- a/src/lib/get-color-area.ts
+++ b/src/lib/get-color-area.ts
@@ -1,16 +1,15 @@
-import type { Area, Colors, Thresholds } from "../types.js";
+import type { TerminalColor, Thresholds } from "../types.js";
+import { AREA_COLORS } from "./constants.js";
 export interface GetColorAreaOptions {
   diffDays: number;
   thresholds: Thresholds;
-  colors: Colors;
 }
 
 export function getColorArea({
   diffDays,
   thresholds,
-  colors,
-}: GetColorAreaOptions): Area {
-  if (diffDays >= thresholds.error) return colors.error;
-  if (diffDays >= thresholds.warn) return colors.warn;
-  return colors.safe;
+}: GetColorAreaOptions): TerminalColor {
+  if (diffDays >= thresholds.error) return AREA_COLORS.error;
+  if (diffDays >= thresholds.warn) return AREA_COLORS.warn;
+  return AREA_COLORS.safe;
 }

--- a/src/lib/process-packages.ts
+++ b/src/lib/process-packages.ts
@@ -1,5 +1,4 @@
 import type {
-  Colors,
   PackagePublishInfo,
   SortBy,
   SortOrder,
@@ -13,7 +12,6 @@ interface ProcessPackageOptions {
   sortBy: SortBy;
   sortOrder: SortOrder;
   thresholds: Thresholds;
-  colors: Colors;
 }
 
 function isDefined<T>(value: T | undefined | null): value is T {
@@ -25,11 +23,10 @@ export function processPackageData({
   sortBy,
   sortOrder,
   thresholds,
-  colors,
 }: ProcessPackageOptions) {
   const validResults = results.filter(isDefined);
   const formatted = validResults.map((pkg) =>
-    formatPackageInfo({ pkg, thresholds, colors }),
+    formatPackageInfo({ pkg, thresholds }),
   );
   return sortPackages(formatted, sortBy, sortOrder);
 }

--- a/src/lib/progress-bar.ts
+++ b/src/lib/progress-bar.ts
@@ -3,9 +3,7 @@ import cliProgress from "cli-progress";
 
 export const progressBar = new cliProgress.SingleBar(
   {
-    format: `Loading ${chalk.cyanBright([
-      "{bar}",
-    ])} {percentage}% | {value}/{total} ${chalk.gray("packages")}`,
+    format: `${chalk.cyanBright(["{bar}"])} {percentage}% | {value}/{total}`,
     hideCursor: true,
   },
   cliProgress.Presets.legacy,

--- a/src/lib/render-table.ts
+++ b/src/lib/render-table.ts
@@ -1,21 +1,7 @@
-import chalk, { type ForegroundColorName, foregroundColorNames } from "chalk";
+import chalk from "chalk";
 import Table from "cli-table3";
 import { formatDistance } from "date-fns";
 import type { PackageInfo } from "../types.js";
-
-export function getChalkColor(color: string): (text: string) => string {
-  if (color.startsWith("#")) {
-    return chalk.hex(color);
-  }
-
-  if (foregroundColorNames.includes(color as ForegroundColorName)) {
-    return chalk[color as ForegroundColorName];
-  }
-
-  throw new Error(
-    `Invalid color: '${color}'. Must be a valid chalk color name or hex code.`,
-  );
-}
 
 const TABLE_HEADER_TITLES = ["Name", "Version", "Date", "Average"] as const;
 
@@ -26,15 +12,15 @@ export function renderTable(packagesInfo: PackageInfo[]) {
 
   for (const pkg of packagesInfo) {
     const { area, averagePublishDays, date, name, version } = pkg;
-    const colorFn = getChalkColor(area);
+    const color = chalk[area];
     const formattedDate = formatDistance(date, new Date(), {
       addSuffix: true,
     });
 
     table.push([
-      colorFn(name),
-      colorFn(version),
-      colorFn(formattedDate),
+      color(name),
+      color(version),
+      color(formattedDate),
       chalk.hex("#2dd4bf")(
         averagePublishDays === 1 ? "daily" : `every ${averagePublishDays} days`,
       ),

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ import { renderTable } from "./lib/render-table.js";
 
 async function main() {
   try {
-    const { packages, sortBy, sortOrder, pattern, colors, thresholds } =
+    const { packages, sortBy, sortOrder, pattern, thresholds } =
       getCliOptions();
 
     const { results, errors } = await fetchPackageInfoList(packages, pattern);
@@ -19,7 +19,6 @@ async function main() {
       sortBy,
       sortOrder,
       thresholds,
-      colors,
     });
 
     renderTable(sortedInfo);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,13 +1,12 @@
-import type { ForegroundColorName } from "chalk";
-
-export type Area = string;
+export type Area = "safe" | "warn" | "error";
+export type TerminalColor = "green" | "yellow" | "red";
 
 export type PackageInfo = {
   name: string;
   version: string;
   date: Date;
   diffDays: number;
-  area: Area;
+  area: TerminalColor;
   averagePublishDays: number;
 };
 
@@ -20,13 +19,7 @@ export type PackagePublishInfo = {
 
 export type SortBy = "name" | "date" | "average";
 export type SortOrder = "asc" | "desc";
-export type ColorOption = ForegroundColorName | `#${string}`;
 export interface Thresholds {
   warn: number;
   error: number;
-}
-export interface Colors {
-  safe: ColorOption;
-  warn: ColorOption;
-  error: ColorOption;
 }


### PR DESCRIPTION
Removed `--safe-color`,` --warn-color`, and `--error-color`.
Colors are now fixed (green/yellow/red) to simplify the **CLI**.
